### PR TITLE
Add archive notice redirecting to monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,7 @@
-# cq-proto
+# cq-proto (Archived)
 
-Protocol buffer definitions for [cq](https://github.com/mozilla-ai/cq) — an
-open standard for shared agent learning.
+This repository has been archived. The protobuf definitions have been
+superseded by JSON Schema in the
+[cq monorepo](https://github.com/mozilla-ai/cq):
 
-## Development
-
-Requires [buf](https://buf.build/docs/installation).
-
-    buf lint              # Lint proto files.
-    buf breaking \        # Check for breaking changes against main.
-      --against '.git#branch=main'
-    buf convert . \       # Validate a fixture.
-      --type cq.v1.KnowledgeUnit \
-      --from fixtures/valid-unit.json
-
-## Schema overview
-
-| File | Contents |
-|------|----------|
-| `cq/v1/knowledge_unit.proto` | `KnowledgeUnit`, `Insight`, `Context`, `Evidence`, `Flag`, `Tier`, `FlagReason` |
-| `cq/v1/scoring.proto` | `RelevanceWeights`, `ConfidenceConstants` |
-| `cq/v1/api.proto` | `TeamAPIService`, `ProposeRequest`, `QueryRequest`, etc. |
-| `cq/v1/review.proto` | `ReviewItem`, `ReviewQueueResponse`, `ReviewStatsResponse`, etc. |
-
-## License
-
-[Apache 2.0](LICENSE)
+- **JSON Schema definitions:** [`schema/`](https://github.com/mozilla-ai/cq/tree/main/schema)


### PR DESCRIPTION
## Summary

- Replace README with archive notice pointing to mozilla-ai/cq monorepo.
- Protobuf definitions have been superseded by JSON Schema.

Prepares this repo for archiving after the monorepo consolidation (mozilla-ai/cq#171).